### PR TITLE
bugfix/SENT-79-FE-long-text

### DIFF
--- a/front-end/src/component/form/CommentForm.tsx
+++ b/front-end/src/component/form/CommentForm.tsx
@@ -112,7 +112,7 @@ const CommentForm: React.FC<Props> = (props) => {
 										resize: 'none',
 										whiteSpace: 'pre-wrap',
 										overflowWrap: 'break-word',
-										overflowY: 'scroll',
+										overflowY: 'auto',
 										maxWidth: '100%',
 										'& .MuiInputBase-input': {
 											fontFamily: 'Poppins',

--- a/front-end/src/component/form/CommentForm.tsx
+++ b/front-end/src/component/form/CommentForm.tsx
@@ -109,10 +109,11 @@ const CommentForm: React.FC<Props> = (props) => {
 									disableUnderline
 									fullWidth
 									sx={{
-										resize: 'vertical',
+										resize: 'none',
 										whiteSpace: 'pre-wrap',
 										overflowWrap: 'break-word',
-										overflowY: 'auto',
+										overflowY: 'scroll',
+										maxWidth: '100%',
 										'& .MuiInputBase-input': {
 											fontFamily: 'Poppins',
 											textAlign: 'justify',

--- a/front-end/src/component/form/CommentForm.tsx
+++ b/front-end/src/component/form/CommentForm.tsx
@@ -105,12 +105,14 @@ const CommentForm: React.FC<Props> = (props) => {
 									error={errors.content ? true : false}
 									multiline
 									minRows={1}
+									maxRows={5}
 									disableUnderline
 									fullWidth
 									sx={{
 										resize: 'vertical',
 										whiteSpace: 'pre-wrap',
 										overflowWrap: 'break-word',
+										overflowY: 'auto',
 										'& .MuiInputBase-input': {
 											fontFamily: 'Poppins',
 											textAlign: 'justify',

--- a/front-end/src/component/form/PostForm.tsx
+++ b/front-end/src/component/form/PostForm.tsx
@@ -122,10 +122,11 @@ const PostForm: React.FC<Props> = (props) => {
 									disableUnderline
 									fullWidth
 									sx={{
-										resize: 'vertical',
+										resize: 'none',
 										whiteSpace: 'pre-wrap',
 										overflowWrap: 'break-word',
 										overflowY: 'auto',
+										maxWidth: '100%',
 										'& .MuiInputBase-input': {
 											fontFamily: 'Poppins',
 											textAlign: 'justify',

--- a/front-end/src/component/form/PostForm.tsx
+++ b/front-end/src/component/form/PostForm.tsx
@@ -118,12 +118,14 @@ const PostForm: React.FC<Props> = (props) => {
 									error={errors.content ? true : false}
 									multiline
 									minRows={1}
+									maxRows={5}
 									disableUnderline
 									fullWidth
 									sx={{
 										resize: 'vertical',
 										whiteSpace: 'pre-wrap',
 										overflowWrap: 'break-word',
+										overflowY: 'auto',
 										'& .MuiInputBase-input': {
 											fontFamily: 'Poppins',
 											textAlign: 'justify',


### PR DESCRIPTION
- [SENT-79 added scroll when text is too long](https://github.com/Be4nz/sent/commit/5e8ae9de9c2172c700d515e92d32e0e8796ec8ab)
- [SENT-79 fixed horizontal scroll bar to not show up](https://github.com/Be4nz/sent/commit/7dc4b31d3e200afbb1c1b81a401559cad3967175)

Results:
- ![image](https://github.com/Be4nz/sent/assets/128229836/93613373-be6d-4f41-bb09-341bc13a31e5)
- ![image](https://github.com/Be4nz/sent/assets/128229836/c478bfde-acc6-48fc-b5d4-e0e67be5e833)